### PR TITLE
feat: Add address_spaces variable to hub stack

### DIFF
--- a/envs/nprd/hub/main.tf
+++ b/envs/nprd/hub/main.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 1.4.6"
+  required_version = ">= 1.5.6"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.67.0"
+      version = ">= 3.71.0"
     }
   }
 
@@ -25,6 +25,11 @@ variable "environment" {
   description = "The environment you are deploying to."
 }
 
+variable "address_spaces" {
+  type        = list(string)
+  description = "The address spaces to use for each region."
+}
+
 variable "regions" {
   type        = list(string)
   description = "A list of the region(s) you are deploying to."
@@ -39,8 +44,9 @@ variable "tags" {
 module "hub" {
   source = "../../../modules/stack/hub"
   # version = ""
-  prefix      = var.prefix
-  environment = var.environment
-  regions     = var.regions
-  tags        = var.tags
+  prefix         = var.prefix
+  environment    = var.environment
+  regions        = var.regions
+  address_spaces = var.address_spaces
+  tags           = var.tags
 }

--- a/modules/stack/hub/firewall_policy.tf
+++ b/modules/stack/hub/firewall_policy.tf
@@ -1,6 +1,6 @@
 resource "azurerm_resource_group" "fwpolicy" {
   location = local.regions[0]
-  name     = module.naming["eastus"].firewall_policy.name
+  name     = module.naming[local.regions[0]].firewall_policy.name
   tags     = local.tags
 }
 

--- a/modules/stack/hub/hub_network.tf
+++ b/modules/stack/hub/hub_network.tf
@@ -1,3 +1,41 @@
+locals {
+  address_spaces = zipmap(var.regions, var.address_spaces)
+
+  hub_virtual_networks = {
+    for r in var.regions : r => {
+      address_space                   = [local.address_spaces[r]]
+      name                            = module.naming[r].firewall.name
+      location                        = azurerm_resource_group.hub[r].location
+      resource_group_name             = azurerm_resource_group.hub[r].name
+      resource_group_creation_enabled = false
+      resource_group_lock_enabled     = false
+      mesh_peering_enabled            = true
+      routing_address_space           = [local.address_spaces[r]]
+      tags                            = local.tags
+      hub_router_ip_address           = "1.2.3.4"
+      subnets = {
+        # The module will currently fail attempting to attach a route table to AzureBastionSubnet
+        AzureBastionSubnet = {
+          address_prefixes             = [module.subnet_addressing[r].network_cidr_blocks["AzureBastionSubnet"]]
+          assign_generated_route_table = false
+        }
+        ServiceNowVMs = {
+          address_prefixes = [module.subnet_addressing[r].network_cidr_blocks["ServiceNowVM"]]
+        }
+      }
+      # firewall = {
+      #   sku_name              = "AZFW_VNet"
+      #   sku_tier              = "Standard"
+      #   threat_intel_mode     = "Off"
+      #   subnet_address_prefix = module.subnet_addressing[r].network_cidr_blocks["AzureFirewallSubnet"]
+      #   firewall_policy_id    = azurerm_firewall_policy.fwpolicy.id
+      #   tags                  = local.tags
+      # }
+    }
+  }
+
+}
+
 resource "azurerm_resource_group" "hub" {
   for_each = toset(local.regions)
 
@@ -6,71 +44,32 @@ resource "azurerm_resource_group" "hub" {
   tags     = local.tags
 }
 
-module "hubnetworks" {
-  source  = "Azure/hubnetworking/azurerm"
-  version = "1.1.0"
-  hub_virtual_networks = {
-    eastus = {
-      address_space                   = [local.address_space[local.primary_region].address_space]
-      name                            = module.naming[local.primary_region].firewall.name
-      location                        = azurerm_resource_group.hub[local.primary_region].location
-      resource_group_name             = azurerm_resource_group.hub[local.primary_region].name
-      resource_group_creation_enabled = false
-      resource_group_lock_enabled     = false
-      mesh_peering_enabled            = true
-      routing_address_space           = [local.address_space[local.primary_region].address_space]
-      tags                            = local.tags
-      hub_router_ip_address           = "1.2.3.4"
-      subnets = {
-        # The module will currently fail attempting to attach a route table to AzureBastionSubnet
-        AzureBastionSubnet = {
-          address_prefixes             = [module.subnet_addressing[local.primary_region].network_cidr_blocks["AzureBastionSubnet"]]
-          assign_generated_route_table = false
-        }
-        ServiceNowVMs = {
-          address_prefixes = [module.subnet_addressing[local.primary_region].network_cidr_blocks["ServiceNowVM"]]
-        }
-      }
-      # firewall = {
-      #   sku_name              = "AZFW_VNet"
-      #   sku_tier              = "Standard"
-      #   threat_intel_mode     = "Off"
-      #   subnet_address_prefix = module.subnet_addressing[local.primary_region].network_cidr_blocks["AzureFirewallSubnet"]
-      #   firewall_policy_id    = azurerm_firewall_policy.fwpolicy.id
-      #   tags                  = local.tags
-      # }
-    }
-    eastus2 = {
-      address_space                   = [local.address_space[local.secondary_region].address_space]
-      name                            = module.naming[local.secondary_region].firewall.name
-      location                        = azurerm_resource_group.hub[local.secondary_region].location
-      resource_group_name             = azurerm_resource_group.hub[local.secondary_region].name
-      resource_group_creation_enabled = false
-      resource_group_lock_enabled     = false
-      mesh_peering_enabled            = true
-      routing_address_space           = [local.address_space[local.secondary_region].address_space]
-      tags                            = local.tags
-      hub_router_ip_address           = "1.2.3.4"
-      subnets = {
-        # The module will currently fail attempting to attach a route table to AzureBastionSubnet
-        AzureBastionSubnet = {
-          address_prefixes             = [module.subnet_addressing[local.secondary_region].network_cidr_blocks["AzureBastionSubnet"]]
-          assign_generated_route_table = false
-        }
-        ServiceNowVMs = {
-          address_prefixes = [module.subnet_addressing[local.secondary_region].network_cidr_blocks["ServiceNowVM"]]
-        }
-      }
-      # firewall = {
-      #   sku_name              = "AZFW_VNet"
-      #   sku_tier              = "Standard"
-      #   threat_intel_mode     = "Off"
-      #   subnet_address_prefix = module.subnet_addressing[local.secondary_region].network_cidr_blocks["AzureFirewallSubnet"]
-      #   firewall_policy_id    = azurerm_firewall_policy.fwpolicy.id
-      #   tags                  = local.tags
-      # }
-    }
-  }
+module "subnet_addressing" {
+  source  = "hashicorp/subnets/cidr"
+  version = "1.0.0"
 
-  depends_on = [azurerm_firewall_policy_rule_collection_group.allow_internal]
+  for_each = local.address_spaces
+
+  base_cidr_block = each.value
+  networks = [
+    {
+      name     = "AzureFirewallSubnet"
+      new_bits = 10
+    },
+    {
+      name     = "AzureBastionSubnet"
+      new_bits = 10
+    },
+    {
+      name     = "ServiceNowVM"
+      new_bits = 8
+    },
+  ]
+}
+
+module "hubnetworks" {
+  source               = "Azure/hubnetworking/azurerm"
+  version              = "1.1.0"
+  hub_virtual_networks = local.hub_virtual_networks
+  depends_on           = [azurerm_firewall_policy_rule_collection_group.allow_internal]
 }

--- a/modules/stack/hub/locals.tf
+++ b/modules/stack/hub/locals.tf
@@ -1,26 +1,5 @@
 locals {
-  regions          = var.regions
-  primary_region   = local.regions[0]
-  secondary_region = local.regions[1]
-
-  address_spaces = { # environments is validated to ensure a valid space here
-    eastus = {
-      sim  = "10.1.0.0/16"
-      nprd = "10.1.0.0/16"
-      prd  = "10.1.0.0/16"
-    }
-    eastus2 = {
-      sim  = "10.2.0.0/16"
-      nprd = "10.2.0.0/16"
-      prd  = "10.2.0.0/16"
-    }
-  }
-
-  address_space = {
-    for region, spaces in local.address_spaces : region => {
-      address_space = spaces[var.environment]
-    }
-  }
+  regions = var.regions
 
   module_tags = {
     environment = var.environment
@@ -29,10 +8,4 @@ locals {
 
   tags = merge(local.module_tags, var.tags)
 
-  dns_virtual_networks_ids = [
-    for r in local.regions : ({
-      id                   = module.hubnetworks.virtual_networks[r].id,
-      registration_enabled = false
-    })
-  ]
 }

--- a/modules/stack/hub/private_dns_zones.tf
+++ b/modules/stack/hub/private_dns_zones.tf
@@ -1,3 +1,12 @@
+locals {
+  dns_virtual_networks_ids = [
+    for r in local.regions : ({
+      id                   = module.hubnetworks.virtual_networks[r].id,
+      registration_enabled = false
+    })
+  ]
+}
+
 module "naming_private_dns" {
   source  = "Azure/naming/azurerm"
   version = "0.3.0"

--- a/modules/stack/hub/utility.tf
+++ b/modules/stack/hub/utility.tf
@@ -5,26 +5,3 @@ module "naming" {
   version = "0.3.0"
   prefix  = [lower(var.prefix), lower(var.environment), "hub", each.value]
 }
-
-module "subnet_addressing" {
-  source  = "hashicorp/subnets/cidr"
-  version = "1.0.0"
-
-  for_each = local.address_space
-
-  base_cidr_block = each.value.address_space
-  networks = [
-    {
-      name     = "AzureFirewallSubnet"
-      new_bits = 10
-    },
-    {
-      name     = "AzureBastionSubnet"
-      new_bits = 10
-    },
-    {
-      name     = "ServiceNowVM"
-      new_bits = 8
-    },
-  ]
-}

--- a/modules/stack/hub/variables.tf
+++ b/modules/stack/hub/variables.tf
@@ -25,3 +25,8 @@ variable "regions" {
   description = "The list of regions where the landing zone resources will be deployed."
   default     = ["eastus", "eastus2", ]
 }
+
+variable "address_spaces" {
+  type        = list(string)
+  description = "The address spaces to use for each region."
+}


### PR DESCRIPTION
- Updates Terraform required version to 1.5.6
- Adds `address_spaces` variable to hub networking stack
  - This addition allows for much more dynamic environment creation
- `hub_virtual_networks` is now dynamically generated
- Cleans up many hardcoded region references
- Moves `locals` to be closer to where they are used
  - `locals` that are used in multiple files are still located in locals.tf
- Moves module call to `subnet_addressing` to be closer to be where it is used