### PR TITLE
Corrects hub_public_ip_prefixes reference

### DIFF
--- a/modules/stack/hub/outputs.tf
+++ b/modules/stack/hub/outputs.tf
@@ -23,7 +23,7 @@ output "hub_base_firewall_policy_id" {
 }
 
 output "hub_public_ip_prefixes" {
-  value = azurerm_public_ip_prefix.hub
+  value = azurerm_public_ip_prefix.bastion
 }
 
 output "hub_private_dns_zones" {


### PR DESCRIPTION
- azurerm_public_ip_prefix.hub was previously renamed to azurerm_public_ip_prefix.bastion, but the output was missed. This PR corrects that error. 